### PR TITLE
Add quotation marks to enable use of colons

### DIFF
--- a/_data/citations.yaml
+++ b/_data/citations.yaml
@@ -552,6 +552,25 @@
   robert-miller: true
   plugin: orcid.py
   file: orcid.yaml
+- id: pmid:26072152
+  title: Hair cortisol concentrations and cortisol stress reactivity predict PTSD
+    symptom increase after trauma exposure during military deployment.
+  authors:
+  - Susann Steudte-Schmiedgen
+  - Tobias Stalder
+  - "Sabine Sch\xF6nfeld"
+  - Hans-Ulrich Wittchen
+  - Sebastian Trautmann
+  - Nina Alexander
+  - Robert Miller
+  - Clemens Kirschbaum
+  publisher: Psychoneuroendocrinology
+  date: '2015-05-23'
+  link: https://www.ncbi.nlm.nih.gov/pubmed/26072152
+  orcid: 0000-0002-8665-5248
+  robert-miller: true
+  plugin: orcid.py
+  file: orcid.yaml
 - id: doi:10.1002/cpp.1936
   title: 'Baseline Patient Characteristics Predicting Outcome and Attrition in Cognitive
     Therapy for Social Phobia: Results from a Large Multicentre Trial'

--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -1,5 +1,5 @@
 - title: Reproduktion und Replikation von Forschungsbefunden
-  subtitle: Betreut durch Robert Miller
+  subtitle: "Betreuer: Robert Miller"
   group: qualifikation
   image: images/quali-ouroboros.jpg
   link: https://i4replication.org/
@@ -8,7 +8,7 @@
     - Bachelor
     
 - title: Meta-Analysen von Interventionsstudien
-  subtitle: Betreut durch Robert Miller
+  subtitle: "Betreuer: Robert Miller"
   group: qualifikation
   image: images/quali-Asklepios-staff.jpg
   link: https://bookdown.org/MathiasHarrer/Doing_Meta_Analysis_in_R/


### PR DESCRIPTION
`:` is a reserved symbol in YAML so any string containing it must be quoted. That's what caused the build errors earlier.