### PR TITLE
Webseite für Suchmaschinen freischalten

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /
+Allow: /


### PR DESCRIPTION
- ändert die `robots.txt` Regeln, so, dass Suchmaschinen die Webseite indexieren und in Suchergebnissen auflisten