### PR TITLE
Revise Georg Hosoya's academic profile and qualifications

### DIFF
--- a/_members/georg-hosoya.md
+++ b/_members/georg-hosoya.md
@@ -12,8 +12,132 @@ links:
   website: https://www.psychologische-hochschule.de/forschung-lehre/dr-georg-hosoya/
 ---
 
-## Forschungs- und Arbeitsschwerpunkte
+## Wissenschaftlicher Werdegang
 
-- Ästhetische Emotionen: ist es möglich, emotionale Reaktionen auf Kunst per Fragebogen zu erfassen und was können wir daraus über Emotionen, Personen und (Kunst)-objekte lernen?
-- Längsschnittliche Modellierung von psychologischen Zuständen: Ist es möglich, Personen hinsichtlich der intraindividuellen Koppelung und Variabilität von psychologischen Zuständen zu differenzieren und was sagt uns das über die Personen?
-- Bayesianische Methoden und Item-Response-Theorie (IRT): können Bayesianische Methoden zur Formulierung neuer diagnostischer IRT-Modelle verwendet werden, um inter- und intraindividuelle Unterschiede in Affekt- und Verhaltensdynamiken im Längsschnitt abzubilden?
+* **seit 10/2023:** Wissenschaftlicher Mitarbeiter am Fachgebiet Psychologische Methodenlehre, Psychologische Hochschule Berlin (PHB)
+* **09/2022 – 10/2023:** **Vertretung der Professur für Psychologische Methodenlehre**, Psychologische Hochschule Berlin (PHB)
+* **09/2021 – 09/2022:** Wissenschaftlicher Mitarbeiter am Arbeitsbereich Forschungsmethoden und Evaluation, Freie Universität Berlin *(8 SWS Lehre zu multivariaten/verteilungsfreien Verfahren)*
+* **01/2019 – 11/2020:** Wissenschaftlicher Mitarbeiter im Drittmittelprojekt zur längsschnittlichen Affektmodellierung bei Borderline-Persönlichkeitsstörung (Ambulatory Assessment), FU Berlin
+* **01/2018 – 12/2018:** Methodischer Berater und wissenschaftlicher Mitarbeiter im Verbundprojekt *ProKomMa* (HU Berlin, FU Berlin, Alice Salomon Hochschule) *(Schwerpunkt: Methodische Betreuung von Promotionen)*
+* **02/2015 – 01/2019:** Wissenschaftlicher Mitarbeiter am Arbeitsbereich Forschungsmethoden und Evaluation, FU Berlin *(Schwerpunkt: Psychometrie impliziter Motive, ästhetische Emotionen, Bayesianische Methoden)*
+* **08/2013 – 01/2015:** **Stellvertretender Leiter des Berliner Standorts** im ERC-Großprojekt *PROPEREMO* (Production and Perception of Emotion, Leitung: Prof. Klaus Scherer), FU Berlin *(Schwerpunkt: Entwicklung von Skalen für ästhetische Reaktionen auf Kunst, Koordination von Feldstudien und Projektfinanzen)*
+* **04/2010 – 10/2012:** Wissenschaftlicher Mitarbeiter und **methodischer Berater am Exzellenzcluster „Languages of Emotion“**, FU Berlin *(Schwerpunkt: Multilevelanalysen)*
+* **10/2004 – 04/2010:** Wissenschaftlicher Mitarbeiter am Institut für Psychologie und Arbeitswissenschaft, Fachgebiet Psychologische Methodenlehre und Statistik (Prof. Dr. Jürgen Bortz), Technische Universität Berlin
+* **2003 – 2004:** Wissenschaftliche Programmierung und Systemadministration am **Max-Planck-Institut für Bildungsforschung**, Berlin *(Forschungsbereich Adaptive Behavior and Cognition)*
+
+## Akademische Qualifikation
+
+* **02/2013:** **Promotion zum Dr. phil.**, Freie Universität Berlin
+*Thema der Dissertation:* „Ein probabilistisches Testmodell zur Erfassung intraindividueller Variabilität“
+* **05/2003:** **Diplom in Psychologie**, Freie Universität Berlin
+*Thema der Diplomarbeit:* „Semantisches Priming und Cluster-Identifikation“
+
+## Profil & Zusatzqualifikationen
+
+* **Forschungsnetzwerke:** Mitglied im DFG-Forschungsnetzwerk *PSIMO* (Entwicklung probabilistischer Modelle zur Messung impliziter Motive).
+* **Freiberufliche Tätigkeit:** Kontinuierliche Beratung in komplexen methodischen Fragen und Durchführung fortgeschrittener Statistik-Workshops (seit 2013).
+* **Software- & Methoden-Expertise:** R, Mplus, JAGS, SPSS, LaTeX (Spezialgebiete: Bayesianische Statistik, Mehrebenenanalyse, Psychometrie, Verteilungsfreie Verfahren).
+* **Sprachkenntnisse:** Englisch (verhandlungssicher), Japanisch (Grundkenntnisse), Französisch.
+* **Mitgliedschaften:** Deutsche Gesellschaft für Psychologie (DGPs; Vollmitglied sowie Fachgruppe Methoden), Ernst-Reuter-Gesellschaft.
+
+## Akademische Selbstverwaltung, Gremien & Betreuung
+
+### Akademische Selbstverwaltung & Kommissionen
+
+* **Akademischer Senat** | Psychologische Hochschule Berlin (PHB)
+* **Berufungs-, Habilitations- und Promotionskommissionen** | Kontinuierliche Mitwirkung in akademischen Prüfungsverfahren an der Freien Universität Berlin und Technischen Universität Berlin
+* **Fakultätsrat & Prüfungsausschuss** | Gremienarbeit und Mitgestaltung der akademischen Selbstverwaltung am Institut für Psychologie und Arbeitswissenschaft, Technische Universität Berlin
+
+### Betreuung wissenschaftlicher Arbeiten
+
+* **Abschlussarbeiten:** Erst- und Zweitbegutachtung von Abschlussarbeiten (Diplom, Bachelor und Master) an der TU Berlin, FU Berlin und der Psychologischen Hochschule Berlin.
+* **Promotionsbetreuung:** Methodische Begleitung und strukturierte Beratung von Promovierenden (u.a. im Rahmen des Verbundprojekts *ProKomMa*).
+
+## Publikationen (Schriftenverzeichnis)
+
+### 1. Empirische Ästhetik & Emotionsforschung
+
+* **Beermann, U., Hosoya, G., Schindler, I., Scherer, K., Eid, M., Wagner, V., & Menninghaus, W.** (2021). Dimensions and Clusters of Aesthetic Emotions: A Semantic Profile Analysis. *Frontiers in Psychology*. [[https://doi.org/10.3389/fpsyg.2021.667173](https://doi.org/10.3389/fpsyg.2021.667173)]
+* **Hosoya, G.** (2019). The artwork and the beholder – a probabilistic model for the joint scaling of objects and persons. *Psychology of Aesthetics, Creativity and the Arts*, 14(2), 224–236. [[https://doi.org/10.1037/aca0000239](https://doi.org/10.1037/aca0000239)]
+* **Hosoya, G., Schindler, I., Beermann, U., Wagner, V., Menninghaus, W., Eid, M., & Scherer, K.** (2017). Mapping the conceptual domain of aesthetic emotion terms – a pile sort study. *Psychology of Aesthetics, Creativity and the Arts*, 11(4). [[https://doi.org/10.1037/aca0000123](https://doi.org/10.1037/aca0000123)]
+* **Schindler, I., Hosoya, G., Menninghaus, W., Beermann, U., Wagner, V., Eid, M., & Scherer, K.** (2017). Measuring aesthetic emotions: A review of the literature and a new assessment tool. *PLoS ONE*, 12(6). [[https://doi.org/10.1371/journal.pone.0178899](https://doi.org/10.1371/journal.pone.0178899)]
+* **Bänziger, T., Hosoya, G., & Scherer, K.** (2015). Path models of vocal emotion communication. *PLoS ONE*, 10(9). [[https://doi.org/10.1371/journal.pone.0136675](https://doi.org/10.1371/journal.pone.0136675)]
+* **Hosoya, G., Bänziger, T., & Scherer, K. R.** (2015). Studying vocal emotion communication from a Brunswikian perspective. *Brunswik Society Newsletter*, 30, 21–22.
+
+### 2. Methodische Modellierung & Psychometrie (Bayes, MLM, IRT)
+
+* **Hosoya, G., Luhmann, M., & Eid, M.** (2019). Modeling discontinuous growth using hierarchical linear models. *Sage Encyclopedia of Research Methods* (Online). [[https://doi.org/10.4135/9781526421036831956](https://doi.org/10.4135/9781526421036831956)]
+* **Hosoya, G., Koch, T., & Eid, M.** (2014). Längsschnittdaten und Mehrebenenanalyse. *Kölner Zeitschrift für Soziologie und Sozialpsychologie*, 66(1). [[https://doi.org/10.1007/s11577-014-0262-9](https://doi.org/10.1007/s11577-014-0262-9)]
+* **Hosoya, G.** (2014). *Einführung in die Analyse testtheoretischer Modelle mit R* – eine praxisorientierte Ergänzung zu dem Buch Testtheorie und Testkonstruktion von Michael Eid und Katharina Schmidt. (Praxisorientiertes Online-Material).
+* **Hosoya, G.** (2013). *Ein probabilistisches Testmodell zur Erfassung intraindividueller Variabilität.* (Dissertation, Freie Universität Berlin).
+
+### 3. Angewandte Psychometrie & Differentielle Psychologie (Klinisch, Pädagogisch, Dyadisch)
+
+* **Gumz, A., Longley, M., Franken, F., Janning, B., Hosoya, G., Derwahl, L., & Kästner, D.** (2023). Who are skilled therapists? Associations between personal characteristics and interpersonal skills in future psychotherapists. *Psychotherapy Research*, 18, 121–122. [[https://doi.org/10.1080/10503307.2023.2259072](https://doi.org/10.1080/10503307.2023.2259072)]
+* **Pohle, L., Hosoya, G., Pohle, J., & Jenßen, L.** (2022). The relationship between early childhood teachers' instructional quality and children's mathematics development. *Learning and Instruction*, 82. [[https://doi.org/10.1016/j.learninstruc.2022.101636](https://doi.org/10.1016/j.learninstruc.2022.101636)]
+* **Hosoya, G., Blömeke, S., Eilerts, K., Jenßen, L., & Eid, M.** (2021). Absolute and relative judgment accuracy: Early childhood teachers‘ competence to evaluate children’s mathematical skills. *Frontiers in Psychology*. [[https://doi.org/10.3389/fpsyg.2021.701730](https://doi.org/10.3389/fpsyg.2021.701730)]
+* **Jegodtka, A., Hosoya, G., Szczesny, M., Jenßen, L., & Schmude, C.** (2021). The relative frequency of mathematical learning opportunities in the morning circle in relation to the development of children's mathematical competencies. In: *Early Childhood Teachers‘ Professional Competence in Mathematics* (pp. 206–217). Routledge.
+* **Keller, J., Hohl, D. H., Hosoya, G., Heuse, S., Scholz, U., Luszczynska, A., & Knoll, N.** (2020). Long-Term Effects of a Dyadic Planning Intervention with Couples Motivated to Increase Physical Activity. *Psychology of Sport & Exercise*, 49. [[https://doi.org/10.1016/j.psychsport.2020.101710](https://doi.org/10.1016/j.psychsport.2020.101710)]
+* **Santangelo, P., Holtmann, J., Hosoya, G., Bohus, M., Kockler, T., Koudela-Hamila, S., Eid, M., & Ebner-Priemer, U.** (2020). Within- and between-person effects of self-esteem and affective state as antecedents and consequences of dysfunctional behaviors in the everyday lives of patients with borderline personality disorder. *Clinical Psychological Science*, 8(3). [[https://doi.org/10.1177/2167702620901724](https://doi.org/10.1177/2167702620901724)]
+* **Jenßen, L., Hosoya, G., Jegodtka, A., Eilerts, K., Eid, M., & Blömeke, S.** (2020). Effects of early childhood teachers' mathematics anxiety on the development of children's mathematical competencies. In: O. Zlatkin-Troitschanskaia, H. A. Pant, M. Toepper, & C. Lautenbach (Eds.), *Student learning in German higher education* (pp. 141–162). Wiesbaden: Springer Fachmedien.
+* **Pohle, L., Hosoya, G., Loftfield, C., & Jenßen, L.** (2019). Indicators measuring preschool teachers' stimulation quality - theoretical background and empirical testing. *Zeitschrift für Pädagogik*, 65(4), 525–541. [[https://doi.org/10.25656/01:23993](https://doi.org/10.25656/01:23993)]
+* **Luhmann, M., Weiss, P., Hosoya, G., & Eid, M.** (2014). Honey, I got fired! A longitudinal dyadic analysis of the effect of unemployment on life satisfaction in couples. *Journal of Personality and Social Psychology*, 107(1), 163–180. [[https://doi.org/10.1037/a0036394](https://doi.org/10.1037/a0036394)]
+* **Knauer, F., & Hosoya, G.** (2018). Studierende mit und ohne Migrationshintergrund als Opfer von Straftaten. *Kriminalistik*, 1, 17–24.
+
+## Lehrprofil & Selbstständige Lehrveranstaltungen
+
+### Quantitative Methoden & Fortgeschrittene Statistik
+
+* **Vorlesungen & Übungen: Statistik I & II (BSc/MSc)** | Kontinuierliche Durchführung (inkl. Blended Learning/Videoaufzeichnungen); PHB (2022–2026), FU Berlin (2022), TU Berlin (2009–2010). *Umfang bis zu 8 SWS pro Semester.*
+* **Vorlesungen & Seminare: Multivariate Analyseverfahren (MSc)** | PHB (2022/2023), FU Berlin (2021/2022).
+* **Vorlesung: Forschungsmethoden (BSc/MSc)** | Regelmäßige Durchführung; PHB (2023–2026)
+* **Vorlesung: Forschungsmethoden (Allgemeines Lineares Modell, Mehrebenenanalyse, logistische Regression) (MsC)** | FU Berlin (2015–2017).
+
+### Spezifische & Höhere methodische Verfahren
+
+* **Bayesianische Methoden für Psycholog*innen (MSc)** | FU Berlin (WiSe 2018/2019).
+* **Einführung in die Mehrebenenanalyse mit R (MSc)** | FU Berlin (2010–2013).
+* **Forschungswerkstatt: Verteilungsfreie / Nonparametrische Verfahren (MSc)** | FU Berlin (2017–2022), TU Berlin (2005–2010).
+
+### Testtheorie, Evaluation & Angewandte Methoden
+
+* **Testtheorie und Testkonstruktion** | Durchgehende Durchführung; TU Berlin (2004–2009).
+* **Evaluation & Methodenkolloquium (MSc)** | PHB (2023, 2026), FU Berlin (2015).
+* **Versuchsplanung** | Verknüpfung mit ingenieurwissenschaftlichen Studiengängen (Human Factors); TU Berlin (2007, 2009).
+
+
+## Wissenschaftliche Vorträge (Auswahl)
+
+* **Hosoya, G.** (2019). *Applying undirected graphical models to the problem of item selection.* 14. Tagung der Fachgruppe Methoden und Evaluation der DGPs, Kiel.
+* **Hosoya, G.** (2018). *An entropy based effect size for logistic regression models.* Workshop for Psychometric Computing (Psychoco), Universität Tübingen.
+* **Hosoya, G.** (2017). *On the relationship between maximum entropy and maximum likelihood methods with applications in psychometrics, categorical data analysis and network analysis.* 13. Tagung der Fachgruppe Methoden & Evaluation der DGPs, Universität Tübingen.
+* **Hosoya, G.** (2017). *Introducing 'ludwig' – A Package for the Statistical Examination of Undirected Binary Networks.* Workshop for Psychometric Computing (Psychoco), Universität Wien. *(Open Source via GitHub)*
+* **Hosoya, G.** (2016). *Das konzeptionelle Feld von Ausdrücken zur Beschreibung von Emotionen in der ästhetischen Erfahrung.* 50. Kongress der Deutschen Gesellschaft für Psychologie (DGPs), Leipzig.
+* **Hosoya, G.** (2016). *Assessing the picture story exercise with two IRT models for forced choice data.* 4. Gemeinsame Tagung der Deutschen Arbeitsgemeinschaft Statistik (DAGSTAT), Universität Göttingen.
+* **Hosoya, G.** (2015). *Ein Item-Response Modell für satzweise kodierte PSE-Daten mit Personen x Karten-Interaktionen.* 13. Arbeitstagung der Fachgruppe Differentielle Persönlichkeitspsychologie und Psychologische Diagnostik, Universität Mainz.
+* **Hosoya, G.** (2014). *The question of reliability in the picture story exercise (PSE): Fitting dynamic multivariate nominal IRT-models to PSE data.* DFG-Netzwerk PSIMO, 49. Kongress der DGPs, Universität Bielefeld.
+* **Hosoya, G.** (2014). *A Maximum Entropy Framework for IRT Modeling.* International Workshop on Psychometric Computing (Psychoco), Universität Tübingen.
+
+## Eingeladene Workshops & Methodentrainings
+
+### Bayesianische Statistik
+
+* **Einführung in Bayesianische Methoden für Psycholog*innen** | Regelmäßige, mehrtägige Intensiv-Workshops für wissenschaftliche Mitarbeiter*innen u.a. an der Freien Universität Berlin (2021), der Psychologischen Hochschule Berlin (2019) und der Universität Hildesheim (2018).
+* **Einführung in Bayesianische Methoden mit R und JAGS** | FU Berlin (2016, 2017; Ko-Leitung).
+
+### Mehrebenenanalyse & R-Programmierung
+
+* **Einführung in die Mehrebenenanalyse mit R** | Eingeladene Key-Workshops u.a. am *LMU Center for Leadership and People Management* (LMU München, 2014), der Universität Hamburg (2015) sowie kontinuierlich an der FU Berlin (2010–2014).
+* **Open Science als Forschungspraxis** | Intensiv-Workshop an der Goethe-Universität Frankfurt (2019).
+* **Einführung in die Statistiksoftware R** | DGfE-Kongress, Berlin (2014).
+
+## Gutachtertätigkeit für wissenschaftliche Fachzeitschriften (Ad-hoc-Reviewer)
+
+* **Methodik & Allgemeine Psychologie:** *Psychometrika*, *Psychological Science*, *PLoS ONE*, *Frontiers in Psychology*
+* **Empirische Ästhetik & Musikpsychologie:** *Psychology of Music*, *Art & Perception*, *Journal of New Music Research*, *Musicae Scientiae*, *International Journal of Applied Positive Psychology*, *Interdisciplinary Science Reviews*
+* **Klinische Psychologie & Psychiatrie:** *BMC Psychiatry*
+
+## Weitere Interessen & Transfer
+
+Natur & Kognition: Zertifizierter Kursleiter für Waldbaden (Shinrin-Yoku). Praktische Beschäftigung mit den kognitiv-affektiven Effekten von Naturräumen auf die psychische Resilienz und Stressregulation (Attention Restoration Theory).
+


### PR DESCRIPTION
Updated the academic profile of Georg Hosoya, including his scientific career, qualifications, teaching profile, publications, and additional interests.

This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
